### PR TITLE
Security fix - Update axios@0.21.1

### DIFF
--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astrajs/collections",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "DataStax Astra's NodeJS collections client",
   "author": "CRW <chris.wilhite@datastax.com>",
   "homepage": "https://github.com/kidrecursive/astrajs#readme",
@@ -36,6 +36,6 @@
     "mocha": "^8.2.0"
   },
   "dependencies": {
-    "@astrajs/rest": "^0.0.6"
+    "@astrajs/rest": "^0.0.7"
   }
 }

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astrajs/rest",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "DataStax Astra's NodeJS REST client",
   "author": "CRW <chris.wilhite@datastax.com>",
   "homepage": "https://github.com/kidrecursive/astrajs#readme",
@@ -30,7 +30,7 @@
     "url": "https://github.com/kidrecursive/astrajs/issues"
   },
   "dependencies": {
-    "axios": "^0.20.0",
+    "axios": "^0.21.1",
     "lodash": "^4.17.20"
   },
   "devDependencies": {


### PR DESCRIPTION
Update axios to v0.21.1 in response to the reported security vulnerability. All tests pass for @astrajs/rest and @astrajs/collections.

# npm audit report

axios  <0.21.1
Severity: high
Server-Side Request Forgery - https://npmjs.com/advisories/1594